### PR TITLE
Theme static tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,3 +137,16 @@ example code we have set `brand` as theme in our CMS)
 
 Its wise to build your templates as you are used to and only override the
 template files you want to customize in your theme.
+
+## theme_static tag
+
+Works just like the standard Django `static` tag, but when a theme is active,
+it will also prefix the theme path.  E.g. If the theme `brand` is active
+`{% theme_static img/logo.png %}` will give /static/theme/brand/img/logo.png
+If no theme was active it'd just be /static/img/logo.png
+
+```python
+{% load theme_static %}
+
+<link rel="apple-touch-icon-precomposed" sizes="144x144" href="{% theme_static 'img/favicon-144x144.png' %}" />
+```

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,8 @@ from setuptools import find_packages, setup
 
 
 install_requires = [
-    'django>=1.8',
-    'wagtail>=1.2'
+    'django>=1.8,<2.0',
+    'wagtail>=1.2,<2.0'
 ]
 
 test_require = [

--- a/src/wagtailthemes/middleware.py
+++ b/src/wagtailthemes/middleware.py
@@ -9,15 +9,13 @@ class ThemeMiddleware(MiddlewareMixin):
     def process_request(self, request):
         try:
             site = request.site
-        except:
-            site = None
-
-        if not site:
+        except AttributeError:
             raise ImproperlyConfigured(
                 "ThemeMiddleware must be added after SiteMiddleware")
 
-        theme_settings = ThemeSettings.for_site(site)
-        theme = theme_settings.theme
+        if site:
+            theme_settings = ThemeSettings.for_site(site)
+            theme = theme_settings.theme
 
-        if theme:
-            set_theme(theme)
+            if theme:
+                set_theme(theme)

--- a/src/wagtailthemes/templatetags/theme_static.py
+++ b/src/wagtailthemes/templatetags/theme_static.py
@@ -6,6 +6,7 @@ from wagtailthemes.models import ThemeSettings
 
 register = template.Library()
 
+
 class ThemeStaticNode(StaticNode):
     def url(self, context):
         path = self.path.resolve(context)
@@ -14,6 +15,7 @@ class ThemeStaticNode(StaticNode):
             theme_path = getattr(settings, 'WAGTAIL_THEME_PATH', "")
             path = os.path.join(theme_path, theme_settings.theme, path)
         return self.handle_simple(path)
+
 
 @register.tag('theme_static')
 def do_theme_static(parser, token):
@@ -24,4 +26,3 @@ def do_theme_static(parser, token):
     but if no theme was active it'd just give /static/img/logo.png
     """
     return ThemeStaticNode.handle_token(parser, token)
-

--- a/src/wagtailthemes/templatetags/theme_static.py
+++ b/src/wagtailthemes/templatetags/theme_static.py
@@ -1,0 +1,27 @@
+import os.path
+from django import template
+from django.conf import settings
+from django.templatetags.static import StaticNode
+from wagtailthemes.models import ThemeSettings
+
+register = template.Library()
+
+class ThemeStaticNode(StaticNode):
+    def url(self, context):
+        path = self.path.resolve(context)
+        theme_settings = ThemeSettings.for_site(context.request.site)
+        if theme_settings.theme:
+            theme_path = getattr(settings, 'WAGTAIL_THEME_PATH', "")
+            path = os.path.join(theme_path, theme_settings.theme, path)
+        return self.handle_simple(path)
+
+@register.tag('theme_static')
+def do_theme_static(parser, token):
+    """
+    Works just like the standard Django static tag, but when a theme is active,
+    it will also prefix the theme path.  E.g. If the theme brand is active
+    {% theme_static img/logo.png %} will give /static/theme/brand/img/logo.png
+    but if no theme was active it'd just give /static/img/logo.png
+    """
+    return ThemeStaticNode.handle_token(parser, token)
+


### PR DESCRIPTION
theme_static tag

Works just like the standard Django `static` tag, but when a theme is active,
it will also prefix the theme path.  E.g. If the theme `brand` is active
{% theme_static img/logo.png %} will give /static/theme/brand/img/logo.png
If no theme was active it'd just be /static/img/logo.png