### PR TITLE
Remove dependency on deprecated SiteMiddleware

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ sudo: false
 dist: xenial
 language: python
 python:
-  - "3.5"
   - "3.6"
   - "3.7"
+  - "3.8"
 install:
   - pip uninstall pytest -y
   - pip install coveralls

--- a/README.md
+++ b/README.md
@@ -60,8 +60,7 @@ INSTALLED_APPS = [
 ]
 ```
 
-Add `ThemeMiddleware` to your `MIDDLEWARE` and make sure its added
-after `SiteMiddleware`
+Add `ThemeMiddleware` to your `MIDDLEWARE`.
 
 ```python
 MIDDLEWARE = [
@@ -72,7 +71,6 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    'wagtail.core.middleware.SiteMiddleware',
     'wagtail.contrib.redirects.middleware.RedirectMiddleware',
     'wagtailthemes.middleware.ThemeMiddleware',
 ]

--- a/example/example/settings.py
+++ b/example/example/settings.py
@@ -68,7 +68,6 @@ MIDDLEWARE = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 
-    # 'wagtail.core.middleware.SiteMiddleware',
     'wagtail.contrib.redirects.middleware.RedirectMiddleware',
 
     'wagtailthemes.middleware.ThemeMiddleware',

--- a/example/example/settings.py
+++ b/example/example/settings.py
@@ -68,7 +68,7 @@ MIDDLEWARE = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 
-    'wagtail.core.middleware.SiteMiddleware',
+    # 'wagtail.core.middleware.SiteMiddleware',
     'wagtail.contrib.redirects.middleware.RedirectMiddleware',
 
     'wagtailthemes.middleware.ThemeMiddleware',

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 install_requires = [
     'django>=2.0',
-    'wagtail>=2.0'
+    'wagtail>=2.9'
 ]
 
 test_require = [
@@ -35,8 +35,8 @@ setup(
         'Framework :: Django',
         'Operating System :: Unix',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7'
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ test_require = [
 
 setup(
     name='wagtail-themes',
-    version='0.3.0',
+    version='0.4.0',
     description='Site specific theme loader for Django Wagtail.',
     author='Rob Moorman',
     author_email='rob@moori.nl',

--- a/src/wagtailthemes/middleware.py
+++ b/src/wagtailthemes/middleware.py
@@ -1,5 +1,6 @@
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.deprecation import MiddlewareMixin
+from wagtail.core.models import Site
 
 from wagtailthemes.models import ThemeSettings
 from wagtailthemes.thread import set_theme
@@ -8,13 +9,13 @@ from wagtailthemes.thread import set_theme
 class ThemeMiddleware(MiddlewareMixin):
     def process_request(self, request):
         try:
-            site = request.site
+            site = Site.find_for_request(request)
         except:  # noqa
             site = None
 
         if not site:
             raise ImproperlyConfigured(
-                "ThemeMiddleware must be added after SiteMiddleware")
+                "Site not found!")
 
         theme_settings = ThemeSettings.for_site(site)
         theme = theme_settings.theme

--- a/src/wagtailthemes/middleware.py
+++ b/src/wagtailthemes/middleware.py
@@ -8,10 +8,7 @@ from wagtailthemes.thread import set_theme
 
 class ThemeMiddleware(MiddlewareMixin):
     def process_request(self, request):
-        try:
-            site = Site.find_for_request(request)
-        except:  # noqa
-            site = None
+        site = Site.find_for_request(request)
 
         if not site:
             raise ImproperlyConfigured(

--- a/src/wagtailthemes/tests/integration/test_middleware.py
+++ b/src/wagtailthemes/tests/integration/test_middleware.py
@@ -1,18 +1,18 @@
 import pytest
 from django.core.exceptions import ImproperlyConfigured
 from django.test.utils import override_settings
+from wagtail.core.models import Site
 
 from wagtailthemes.thread import get_theme, set_theme
 
 
 @pytest.mark.django_db
-def test_middleware_not_configured(client):
+def test_middleware_no_site(client):
     with override_settings(MIDDLEWARE=[
-        'django.contrib.sessions.middleware.SessionMiddleware',
-        'django.middleware.common.CommonMiddleware',
         'wagtailthemes.middleware.ThemeMiddleware',
-        # 'wagtail.core.middleware.SiteMiddleware',
     ]):
+        # Remove all sites to simulate not being able to find the site.
+        Site.objects.all().delete()
         with pytest.raises(ImproperlyConfigured):
             client.get('/')
 

--- a/src/wagtailthemes/tests/integration/test_middleware.py
+++ b/src/wagtailthemes/tests/integration/test_middleware.py
@@ -11,7 +11,7 @@ def test_middleware_not_configured(client):
         'django.contrib.sessions.middleware.SessionMiddleware',
         'django.middleware.common.CommonMiddleware',
         'wagtailthemes.middleware.ThemeMiddleware',
-        'wagtail.core.middleware.SiteMiddleware',
+        # 'wagtail.core.middleware.SiteMiddleware',
     ]):
         with pytest.raises(ImproperlyConfigured):
             client.get('/')

--- a/src/wagtailthemes/tests/settings.py
+++ b/src/wagtailthemes/tests/settings.py
@@ -65,7 +65,6 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    # 'wagtail.core.middleware.SiteMiddleware',
     'wagtail.contrib.redirects.middleware.RedirectMiddleware',
     'wagtailthemes.middleware.ThemeMiddleware',
 ]

--- a/src/wagtailthemes/tests/settings.py
+++ b/src/wagtailthemes/tests/settings.py
@@ -65,7 +65,7 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    'wagtail.core.middleware.SiteMiddleware',
+    # 'wagtail.core.middleware.SiteMiddleware',
     'wagtail.contrib.redirects.middleware.RedirectMiddleware',
     'wagtailthemes.middleware.ThemeMiddleware',
 ]


### PR DESCRIPTION
Based off #19. Thanks for your work done there @jcuotpc! :tada: 

This pull request will remove the dependency on `wagtail.core.middleware.SiteMiddleware` and use the recommended `Site.find_for_request(request)` alternative instead.

[`SiteMiddleware` was deprecated in Wagtail 2.9.](https://docs.wagtail.io/en/v2.9/releases/2.9.html#sitemiddleware-and-request-site-deprecated)

This pull request also adds Python 3.8 support and drops Python 3.5 from Travis. We should think about implementing a more robust testing strategy as described in #11.